### PR TITLE
Implement "predictor" loader

### DIFF
--- a/etc/config.json
+++ b/etc/config.json
@@ -1,4 +1,10 @@
 {
   "MUSCLE": "tools/muscle3",
-  "NACCESS": "tools/naccess.config"
+  "NACCESS": "tools/naccess.config",
+  "predictors": [
+    "whiscy",
+    "scriber",
+    "ispred4",
+    "placeholder"
+  ]
 }

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -1,25 +1,11 @@
 import argparse
+import json
 import logging
-
-import os
 import sys
+from pathlib import Path
+
+from cport.modules.loader import run_prediction
 from cport.version import VERSION
-
-# from cport.modules.tools import (
-#     calc_sasa,
-#     parser,
-#     predictors,
-#     reconstruct_pdb,
-#     residiues_distance,
-#     save_csv,
-#     threshold,
-#     validations,
-# )
-# from cport.modules.utils import get_unique_folder, run
-from cport.modules.whiscy import Whiscy
-from cport.modules.scriber import Scriber
-from cport.modules.ispred4 import Ispred4
-
 
 # Setup logging
 log = logging.getLogger("cportlog")
@@ -29,6 +15,9 @@ formatter = logging.Formatter(
 )
 ch.setFormatter(formatter)
 log.addHandler(ch)
+
+
+CONFIG = json.load(open(Path(Path(__file__).parents[2], "etc/config.json")))
 
 # ===========================================================================================================
 # Define arguments
@@ -40,6 +29,19 @@ ap.add_argument(
 
 ap.add_argument(
     "chain_id",
+    help="",
+)
+
+ap.add_argument(
+    "--fasta_file",
+    help="",
+)
+
+ap.add_argument(
+    "--pred",
+    nargs="+",
+    default=["all"],
+    choices=CONFIG["predictors"] + ["all"],
     help="",
 )
 
@@ -73,160 +75,27 @@ def maincli():
 
 # ====================================================================================#
 # Main code
-def main(pdb_id, chain_id):
+def main(pdb_id, chain_id, pred, fasta_file):
 
     # Start #=========================================================================#
     log.setLevel("DEBUG")
     log.info("-" * 42)
-    log.info(f"          Welcome to CPORT v{VERSION}")
+    log.info(f" Welcome to CPORT v{VERSION}")
     log.info("-" * 42)
 
-    # Run whiscy
-    whiscy = Whiscy(pdb_id, chain_id)
-    whiscy_predictions = whiscy.run()
-    log.info(whiscy_predictions)
+    # Run predictors #================================================================#
+    data = {"pdb_id": pdb_id, "chain_id": chain_id, "fasta_file": fasta_file}
 
-    # Run SCRIBER
-    scriber = Scriber(pdb_id, chain_id)
-    scriber_predictions = scriber.run()
-    log.info(scriber_predictions)
+    if "all" in pred:
+        pred = CONFIG["predictors"]
 
-    # Run ISPRED4
-    ispred4 = Ispred4(pdb_id, chain_id)
-    ispred4_predictions = ispred4.run()
-    log.info(ispred4_predictions)
-
-    # try:
-    #     # Main directory of the project
-    #     cport_dir = os.path.dirname(os.path.realpath(__file__))
-
-    #     """Command-line arguments"""
-    #     if len(sys.argv) > 1:
-    #         arg_parser = argparse.ArgumentParser()
-
-    #         # All of the arguments are set as optional
-    #         # They are validated in a later process
-    #         arg_parser.add_argument(
-    #             "-chain_id", help="optional argument", dest="chain_id"
-    #         )
-    #         arg_parser.add_argument(
-    #             "-threshold",
-    #             help="optional preset to 3",
-    #             type=int,
-    #             default=3,
-    #             dest="threshold",
-    #         )
-    #         arg_parser.add_argument(
-    #             "-pdb_id", help="give the id of the pdb XXXX", dest="pdb_id"
-    #         )
-    #         arg_parser.add_argument(
-    #             "-pdb_file",
-    #             help="load the pdb from a local file",
-    #             type=validations.pdb_assertions,
-    #             dest="pdb_file",
-    #         )
-    #         arg_parser.add_argument(
-    #             "-sequence_file",
-    #             help="load the seq from a local file",
-    #             type=validations.seq_assertions,
-    #             dest="seq_file",
-    #         )
-    #         arg_parser.add_argument(
-    #             "-alignment_format",
-    #             help="give the format of the alignment",
-    #             choices=["FASTA", "CLUSTAL", "MAF", "PHYLIP"],
-    #             dest="al",
-    #         )
-    #         arg_parser.add_argument(
-    #             "-servers",
-    #             help=(
-    #                 "Choose between: whiscy(1) promate(2) meta_ppisp(3) spidder(4)     "
-    #                 "                                Can select by Numbers,Names       "
-    #                 "                               Can also use range ex 1:4 (All"
-    #                 " servers)                                       Default value: All"
-    #             ),
-    #             nargs="+",
-    #             default=["all"],
-    #         )
-
-    #         cl_arguments = arg_parser.parse_args()
-    #         validations.argument_assertions(cl_arguments)
-    #     else:
-    #         raise AssertionError("Please provide pdb_id or pdb_file")
-
-    #     # Generation of a random and unique directory run_*
-    #     pdb_name, run_dir = get_unique_folder(cport_dir, cl_arguments)
-    #     if not os.path.exists(run_dir):
-    #         os.mkdir(run_dir)
-
-    #     # Parse the input arguments in the object
-    #     # Convert to the required formats
-    #     print("Preparing the input files" + os.linesep)
-    #     input_params = parser.run(cl_arguments, run_dir)
-    #     print("Input files are ready" + os.linesep)
-
-    #     # Multiprocessing function, webservers in parallel run
-    #     # The outcome of the predictors is stored in a list of objects
-    #     web_results = run(input_params, main_dir=run_dir, pdb_name=pdb_name)
-    #     n_web_servers = len(web_results.values())
-    #     print(f"Number of webservers: {n_web_servers}" + os.linesep)
-    #     n_success = sum([i.success for i in web_results.values()])
-    #     print(f"Successful predictors: {n_success}" + os.linesep)
-
-    #     # Add the threshold values based on the successful predictors
-    #     print(
-    #         "Update the threshold values based on the successful predictors"
-    #         + os.linesep
-    #     )
-    #     predictors_list = threshold.run(
-    #         web_results.values(), cport_dir, run_dir, input_params.threshold
-    #     )
-
-    #     # Solvent Accessible Surface Area calculations
-    #     # Return a list of residues and the values
-    #     # In some cases freesasa return N/A
-    #     # I am not sure what I should do, for now I remove these residue
-    #     # Freesasa needs to be installed
-    #     print("Calculate solvent accessible surface area" + os.linesep)
-    #     surface = calc_sasa.run(input_params.pdb_file)
-
-    #     # Distance Calculations between two residues (list of tuples)
-    #     # The tools/resdist must be recompiled
-    #     print("Calculate the residues distance" + os.linesep)
-    #     distance_list = residiues_distance.run(input_params, cport_dir)
-
-    #     # Update the active and passive residues using filters from Cport
-    #     print(
-    #         "Filter the residues based on precalculated residues and threshold"
-    #         + os.linesep
-    #     )
-
-    #     fpredictors = predictors.update_res(
-    #         predictor_list=predictors_list, surface=surface, distance_list=distance_list
-    #     )
-
-    #     # Reconstruction of the final pdb based on the active/passive residues
-    #     print("Construct the final PDB" + os.linesep)
-    #     reconstruct_pdb.run(
-    #         init_pdb=input_params.pdb_file,
-    #         predictors_list=fpredictors,
-    #         main_dir=run_dir,
-    #     )
-
-    #     # Final table of each predictor and the active/passive residues
-    #     print("Create the residues table" + os.linesep)
-    #     save_csv.run(fpredictors, input_params.pdb_file, run_dir)
-
-    #     cmd_file = os.path.join(run_dir, "cl_cmd.txt")
-    #     with open(cmd_file, "w") as f:
-    #         f.write(" ".join(sys.argv))
-    #         f.write(os.linesep)
-    #         f.write(f"Successful predictors: {n_success}")
-    #     f.close()
-
-    # except AssertionError as ae:
-    #     print(ae)
-    #     raise SystemExit()
+    for predictor in pred:
+        try:
+            run_prediction(predictor, **data)
+        except Exception as e:
+            log.error(f"Error running {predictor}")
+            log.error(e)
+            sys.exit()
 
 
 if __name__ == "__main__":

--- a/src/cport/modules/error.py
+++ b/src/cport/modules/error.py
@@ -1,0 +1,18 @@
+class Error(Exception):
+    """Base class for other exceptions"""
+
+
+class IncompleteInputError(Error):
+    """Raised when input is incomplete for a given predictor."""
+
+    def __init__(self, predictor_name, missing=None):
+        self.predictor_name = predictor_name
+        self.message = "Incomplete input for"
+        self.missing = missing
+        super().__init__(self.message)
+
+    def __str__(self):
+        if self.missing:
+            return f"{self.message} {self.predictor_name} predictor, missing: {self.missing}"
+        else:
+            return f"{self.message} {self.predictor_name}"

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -1,0 +1,79 @@
+import logging
+from functools import partial
+
+from cport.modules.error import IncompleteInputError
+from cport.modules.ispred4 import Ispred4
+from cport.modules.scriber import Scriber
+from cport.modules.whiscy import Whiscy
+
+log = logging.getLogger("cportlog")
+
+
+def run_whiscy(pdb_id, chain_id):
+    """Run the WHISCY predictor."""
+    whiscy = Whiscy(pdb_id, chain_id)
+    whiscy_predictions = whiscy.run()
+    log.info(whiscy_predictions)
+
+
+def run_ispred4(pdb_id, chain_id):
+    """Run the ispred4 predictor."""
+    ispred4 = Ispred4(pdb_id, chain_id)
+    ispred4_predictions = ispred4.run()
+    log.info(ispred4_predictions)
+
+
+def run_scriber(pdb_id, chain_id):
+    """Run the scriber predictor."""
+    scriber = Scriber(pdb_id, chain_id)
+    scriber_predictions = scriber.run()
+    log.info(scriber_predictions)
+
+
+def run_placeholder(fasta_str):
+    """Run the placeholder predictor."""
+    log.info("Placeholder predictor")
+    log.info(f"fasta_str: {fasta_str}")
+
+
+PDB_PREDICTORS = {
+    "whiscy": run_whiscy,
+    "scriber": run_scriber,
+    "ispred4": run_ispred4,
+}
+
+FASTA_PREDICTORS = {"placeholder": run_placeholder}
+
+
+def run_prediction(prediction_method, **kwargs):
+    """Select predictors to run."""
+    if prediction_method in PDB_PREDICTORS:
+        if not kwargs["pdb_id"]:
+            raise IncompleteInputError(
+                predictor_name=prediction_method, missing="pdb_id"
+            )
+
+        if not kwargs["chain_id"]:
+            raise IncompleteInputError(
+                predictor_name=prediction_method, missing="chain_id"
+            )
+
+        predictor_func = partial(
+            PDB_PREDICTORS[prediction_method],
+            pdb_id=kwargs["pdb_id"],
+            chain_id=kwargs["chain_id"],
+        )
+
+    elif prediction_method in FASTA_PREDICTORS:
+        if not kwargs["fasta_file"]:
+            raise IncompleteInputError(
+                predictor_name=prediction_method, missing="fasta_file"
+            )
+        predictor_func = partial(
+            FASTA_PREDICTORS[prediction_method], fasta_str=kwargs["fasta_file"]
+        )
+    else:
+        raise ValueError(f"Unknown prediction method: {prediction_method}")
+
+    log.info(f"Running method: {prediction_method}")
+    predictor_func()

--- a/src/cport/version.py
+++ b/src/cport/version.py
@@ -1,2 +1,2 @@
-VERSION = "0.1.0"
+VERSION = "0.1.0-unreleased"
 v_major, v_minor, v_patch = VERSION.split(".")


### PR DESCRIPTION
This PR closes #11 by implementing a way to only run some of the predictors;

By default it will run all, or the possible ones can be passed as an argument:

`cport 1PPE E --pred whiscy ispred4`

The list of available predictors are available at `config.json`

I've also included a placeholder for when we start dealing with fasta-based predictors.