### PR TITLE
Change parsing of result table of `predictprotein`

### DIFF
--- a/src/cport/modules/predictprotein.py
+++ b/src/cport/modules/predictprotein.py
@@ -193,10 +193,13 @@ class Predictprotein:
         )
 
         for row in final_predictions.itertuples():
-            if row.Protein_Pred == 1:  # 1 indicates interaction
-                prediction_dict["active"].append(row[0])
-            elif row.Protein_Pred == 0:  # 0 indicates no interaction
-                prediction_dict["passive"].append(row[0])
+            # 1 indicates interaction
+            interaction = True if row.Protein_Pred == 1 else False
+            residue_number = int(row.Residue_Number.split('_')[-1])
+            if interaction:
+                prediction_dict["active"].append(residue_number)
+            elif not interaction:
+                prediction_dict["passive"].append(residue_number)
             else:
                 log.warning(
                     f"There appears that residue {row} is either empty or unprocessable"

--- a/src/cport/modules/predictprotein.py
+++ b/src/cport/modules/predictprotein.py
@@ -195,7 +195,7 @@ class Predictprotein:
         for row in final_predictions.itertuples():
             # 1 indicates interaction
             interaction = True if row.Protein_Pred == 1 else False
-            residue_number = int(row.Residue_Number.split('_')[-1])
+            residue_number = int(row.Residue_Number.split("_")[-1])
             if interaction:
                 prediction_dict["active"].append(residue_number)
             elif not interaction:

--- a/tests/test_predictprotein.py
+++ b/tests/test_predictprotein.py
@@ -32,6 +32,9 @@ def test_parse_prediction(predictprotein, precalc_result):
     assert "active" in observed_result_dic
     assert "passive" in observed_result_dic
 
+    assert 0 not in observed_result_dic["active"]
+    assert 0 not in observed_result_dic["passive"]
+
     assert len(observed_result_dic["active"]) == 29
     assert len(observed_result_dic["passive"]) == 194
 


### PR DESCRIPTION
This PR closes #38 by changing the way the residue numbers are extracted from the result file of `predictprotein`