### PR TITLE
Implement the use of a PDB file instead of ID as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please also refer to the original publication:
 | [ISPRED4](https://ispred4.biocomp.unibo.it/ispred/default/index) | 🟢     | ✔️          |
 | [SPPIDER](https://sppider.cchmc.org)                             | 🟢     | ✔️          |
 | [meta-PPISP](https://pipe.rcc.fsu.edu/meta-ppisp.html)           | 🟢     | ✔️          |
-| [PredUs2](http://honig.c2b2.columbia.edu/predus)                 | 🟢     | ✔️          |
+| [PredUs2](http://honig.c2b2.columbia.edu/predus)                 | 🟠     | ✔️          |
 | [Cons-PPISP](https://pipe.rcc.fsu.edu/ppisp.html)                | 🟢     | ✔️          |
 | [PredictProtein](https://predictprotein.org)                     | 🟢     | ✔️          |
 | [PSIVER](https://mizuguchilab.org/PSIVER/)                       | 🟢     | ✔️          |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please refer to [INSTALL.md](INSTALL.md) for installation instructions.
 ## Example
 
 ```text
-cport 1PPE E
+cport path/to/file.pdb E
 ```
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please refer to [INSTALL.md](INSTALL.md) for installation instructions.
 ## Example
 
 ```text
-cport path/to/file.pdb E
+cport path/to/file/1PPE.pdb E
 ```
 
 ## How to contribute

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 chromedriver-py==102.0.5005.61
 click==8.1.2
+defusedxml==0.7.1
 freesasa==2.1.0
 idna==3.3
 isort==5.10.1

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -35,6 +35,11 @@ argument_parser.add_argument(
 )
 
 argument_parser.add_argument(
+    "pdb_file",
+    help="",
+)
+
+argument_parser.add_argument(
     "--fasta_file",
     help="",
 )
@@ -100,7 +105,7 @@ def maincli():
 
 # ====================================================================================#
 # Main code
-def main(pdb_id, chain_id, pred, fasta_file):
+def main(pdb_id, chain_id, pdb_file, pred, fasta_file):
     """
     Execute main function.
 
@@ -110,6 +115,8 @@ def main(pdb_id, chain_id, pred, fasta_file):
         Protein data bank identification code.
     chain_id : str
         Chain identifier.
+    pdb_file : str
+        Path to pdb file.
     pred : list
         List of predictors to run.
     fasta_file : str
@@ -123,7 +130,12 @@ def main(pdb_id, chain_id, pred, fasta_file):
     log.info("-" * 42)
 
     # Run predictors #================================================================#
-    data = {"pdb_id": pdb_id, "chain_id": chain_id, "fasta_file": fasta_file}
+    data = {
+        "pdb_id": pdb_id,
+        "chain_id": chain_id,
+        "fasta_file": fasta_file,
+        "pdb_file": pdb_file,
+    }
     result_dic = {}
 
     if "all" in pred:

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -154,8 +154,8 @@ def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
     format_output(
         result_dic,
         output_fname="cport.csv",
-        chain_id=chain_id,
         pdb_file=pdb_file,
+        chain_id=chain_id,
     )
 
 

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -152,7 +152,10 @@ def main(pdb_id, chain_id, pdb_file, pred, fasta_file):
 
     # Ouput results #==================================================================#
     format_output(
-        result_dic, output_fname="cport.csv", pdb_id=pdb_id, chain_id=chain_id
+        result_dic,
+        output_fname="cport.csv",
+        chain_id=chain_id,
+        pdb_file=pdb_file,
     )
 
 

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -25,7 +25,7 @@ CONFIG = json.load(open(Path(Path(__file__).parents[2], "etc/config.json")))
 # Define arguments
 argument_parser = argparse.ArgumentParser()
 argument_parser.add_argument(
-    "pdb_id",
+    "pdb_file",
     help="",
 )
 
@@ -35,7 +35,7 @@ argument_parser.add_argument(
 )
 
 argument_parser.add_argument(
-    "pdb_file",
+    "--pdb_id",
     help="",
 )
 
@@ -105,7 +105,7 @@ def maincli():
 
 # ====================================================================================#
 # Main code
-def main(pdb_id, chain_id, pdb_file, pred, fasta_file):
+def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
     """
     Execute main function.
 

--- a/src/cport/modules/csm_potential.py
+++ b/src/cport/modules/csm_potential.py
@@ -7,7 +7,6 @@ import time
 import pandas as pd
 import requests
 
-from cport.modules.utils import get_pdb_from_pdbid
 from cport.url import CSM_POTENTIAL_URL
 
 log = logging.getLogger("cportlog")
@@ -21,7 +20,7 @@ ELEMENT_LOAD_WAIT = 5  # seconds
 class CsmPotential:
     """CSM_POTENTIAL class."""
 
-    def __init__(self, pdb_id, chain_id):
+    def __init__(self, pdb_id, chain_id, pdb_file):
         """
         Initialize the class.
 
@@ -31,10 +30,13 @@ class CsmPotential:
             Protein data bank identification code.
         chain_id : str
             Chain identifier.
+        pdb_file : str
+            Path to pdb file.
 
         """
         self.pdb_id = pdb_id
         self.chain_id = chain_id
+        self.pdb_file = pdb_file
         self.wait = WAIT_INTERVAL
         self.tries = NUM_RETRIES
 
@@ -49,8 +51,7 @@ class CsmPotential:
             prediction results.
 
         """
-        pdb_file = get_pdb_from_pdbid(self.pdb_id)
-        data = {"pdb_file": open(pdb_file), "chain": self.chain_id}
+        data = {"pdb_file": open(self.pdb_file)}
 
         req = requests.post(CSM_POTENTIAL_URL, files=data)
 

--- a/src/cport/modules/csm_potential.py
+++ b/src/cport/modules/csm_potential.py
@@ -30,8 +30,6 @@ class CsmPotential:
             Path to PDB file.
         chain_id : str
             Chain identifier.
-        pdb_file : str
-            Path to pdb file.
 
         """
         self.chain_id = chain_id

--- a/src/cport/modules/csm_potential.py
+++ b/src/cport/modules/csm_potential.py
@@ -20,21 +20,20 @@ ELEMENT_LOAD_WAIT = 5  # seconds
 class CsmPotential:
     """CSM_POTENTIAL class."""
 
-    def __init__(self, pdb_id, chain_id, pdb_file):
+    def __init__(self, pdb_file, chain_id):
         """
         Initialize the class.
 
         Parameters
         ----------
-        pdb_id : str
-            Protein data bank identification code.
+        pdb_file : str
+            Path to PDB file.
         chain_id : str
             Chain identifier.
         pdb_file : str
             Path to pdb file.
 
         """
-        self.pdb_id = pdb_id
         self.chain_id = chain_id
         self.pdb_file = pdb_file
         self.wait = WAIT_INTERVAL

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -17,14 +17,14 @@ from cport.modules.whiscy import Whiscy
 log = logging.getLogger("cportlog")
 
 
-def run_whiscy(pdb_id, chain_id, pdb_file):
+def run_whiscy(pdb_file, chain_id):
     """
     Run the WHISCY predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -34,7 +34,7 @@ def run_whiscy(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    whiscy = Whiscy(pdb_id, chain_id, pdb_file)
+    whiscy = Whiscy(pdb_file, chain_id)
     predictions = whiscy.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -40,10 +40,7 @@ def run_whiscy(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_ispred4(
-    pdb_file,
-    chain_id,
-):
+def run_ispred4(pdb_file, chain_id):
     """
     Run the ISPRED4 predictor.
 
@@ -135,14 +132,14 @@ def run_cons_ppisp(pdb_file, chain_id):
     return predictions
 
 
-def run_meta_ppisp(pdb_id, chain_id, pdb_file):
+def run_meta_ppisp(pdb_file, chain_id):
     """
     Run the META-PPISP predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -152,7 +149,7 @@ def run_meta_ppisp(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    meta_ppisp = MetaPPISP(pdb_id, chain_id, pdb_file)
+    meta_ppisp = MetaPPISP(pdb_file, chain_id)
     predictions = meta_ppisp.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -155,14 +155,14 @@ def run_meta_ppisp(pdb_file, chain_id):
     return predictions
 
 
-def run_predus2(pdb_id, chain_id, pdb_file):
+def run_predus2(pdb_file, chain_id):
     """
     Run the WHISCY predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -172,7 +172,7 @@ def run_predus2(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    predus2 = Predus2(pdb_id, chain_id, pdb_file)
+    predus2 = Predus2(pdb_file, chain_id)
     predictions = predus2.run()
     log.info(predictions)
     return predictions
@@ -201,14 +201,14 @@ def run_predictprotein(pdb_file, chain_id):
     return predictions
 
 
-def run_psiver(pdb_id, chain_id, pdb_file):
+def run_psiver(pdb_file, chain_id):
     """
     Run the PSIVER predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -218,7 +218,7 @@ def run_psiver(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    psiver = Psiver(pdb_id, chain_id, pdb_file)
+    psiver = Psiver(pdb_file, chain_id)
     predictions = psiver.run()
     log.info(predictions)
     return predictions
@@ -230,8 +230,8 @@ def run_csm_potential(pdb_file, chain_id):
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -224,7 +224,7 @@ def run_psiver(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_csm_potential(pdb_id, chain_id, pdb_file):
+def run_csm_potential(pdb_file, chain_id):
     """
     Run the PSIVER predictor.
 
@@ -241,7 +241,7 @@ def run_csm_potential(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    csm_potential = CsmPotential(pdb_id, chain_id, pdb_file)
+    csm_potential = CsmPotential(pdb_file, chain_id)
     predictions = csm_potential.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -109,14 +109,14 @@ def run_sppider(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_cons_ppisp(pdb_id, chain_id, pdb_file):
+def run_cons_ppisp(pdb_file, chain_id):
     """
     Run the CONS-PPISP predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -126,7 +126,7 @@ def run_cons_ppisp(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    cons_ppisp = ConsPPISP(pdb_id, chain_id, pdb_file)
+    cons_ppisp = ConsPPISP(pdb_file, chain_id)
     predictions = cons_ppisp.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -69,8 +69,8 @@ def run_scriber(pdb_file, chain_id):
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -224,7 +224,7 @@ def run_psiver(pdb_id, chain_id):
     return predictions
 
 
-def run_csm_potential(pdb_id, chain_id):
+def run_csm_potential(pdb_id, chain_id, pdb_file):
     """
     Run the PSIVER predictor.
 
@@ -241,7 +241,7 @@ def run_csm_potential(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    csm_potential = CsmPotential(pdb_id, chain_id)
+    csm_potential = CsmPotential(pdb_id, chain_id, pdb_file)
     predictions = csm_potential.run()
     log.info(predictions)
     return predictions
@@ -317,6 +317,7 @@ def run_prediction(prediction_method, **kwargs):
             PDB_PREDICTORS[prediction_method],
             pdb_id=kwargs["pdb_id"],
             chain_id=kwargs["chain_id"],
+            pdb_file=kwargs["pdb_file"],
         )
 
     elif prediction_method in FASTA_PREDICTORS:

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -40,14 +40,17 @@ def run_whiscy(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_ispred4(pdb_id, chain_id, pdb_file):
+def run_ispred4(
+    pdb_file,
+    chain_id,
+):
     """
     Run the ISPRED4 predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -57,7 +60,7 @@ def run_ispred4(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    ispred4 = Ispred4(pdb_id, chain_id, pdb_file)
+    ispred4 = Ispred4(pdb_file, chain_id)
     predictions = ispred4.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -17,7 +17,7 @@ from cport.modules.whiscy import Whiscy
 log = logging.getLogger("cportlog")
 
 
-def run_whiscy(pdb_id, chain_id):
+def run_whiscy(pdb_id, chain_id, pdb_file):
     """
     Run the WHISCY predictor.
 
@@ -34,13 +34,13 @@ def run_whiscy(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    whiscy = Whiscy(pdb_id, chain_id)
+    whiscy = Whiscy(pdb_id, chain_id, pdb_file)
     predictions = whiscy.run()
     log.info(predictions)
     return predictions
 
 
-def run_ispred4(pdb_id, chain_id):
+def run_ispred4(pdb_id, chain_id, pdb_file):
     """
     Run the ISPRED4 predictor.
 
@@ -57,13 +57,13 @@ def run_ispred4(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    ispred4 = Ispred4(pdb_id, chain_id)
+    ispred4 = Ispred4(pdb_id, chain_id, pdb_file)
     predictions = ispred4.run()
     log.info(predictions)
     return predictions
 
 
-def run_scriber(pdb_id, chain_id):
+def run_scriber(pdb_id, chain_id, pdb_file):
     """
     Run the SCRIBER predictor.
 
@@ -80,13 +80,13 @@ def run_scriber(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    scriber = Scriber(pdb_id, chain_id)
+    scriber = Scriber(pdb_id, chain_id, pdb_file)
     predictions = scriber.run()
     log.info(predictions)
     return predictions
 
 
-def run_sppider(pdb_id, chain_id):
+def run_sppider(pdb_id, chain_id, pdb_file):
     """
     Run the WHISCY predictor.
 
@@ -103,13 +103,13 @@ def run_sppider(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    sppider = Sppider(pdb_id, chain_id)
+    sppider = Sppider(pdb_id, chain_id, pdb_file)
     predictions = sppider.run()
     log.info(predictions)
     return predictions
 
 
-def run_cons_ppisp(pdb_id, chain_id):
+def run_cons_ppisp(pdb_id, chain_id, pdb_file):
     """
     Run the CONS-PPISP predictor.
 
@@ -126,13 +126,13 @@ def run_cons_ppisp(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    cons_ppisp = ConsPPISP(pdb_id, chain_id)
+    cons_ppisp = ConsPPISP(pdb_id, chain_id, pdb_file)
     predictions = cons_ppisp.run()
     log.info(predictions)
     return predictions
 
 
-def run_meta_ppisp(pdb_id, chain_id):
+def run_meta_ppisp(pdb_id, chain_id, pdb_file):
     """
     Run the META-PPISP predictor.
 
@@ -149,13 +149,13 @@ def run_meta_ppisp(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    meta_ppisp = MetaPPISP(pdb_id, chain_id)
+    meta_ppisp = MetaPPISP(pdb_id, chain_id, pdb_file)
     predictions = meta_ppisp.run()
     log.info(predictions)
     return predictions
 
 
-def run_predus2(pdb_id, chain_id):
+def run_predus2(pdb_id, chain_id, pdb_file):
     """
     Run the WHISCY predictor.
 
@@ -172,13 +172,13 @@ def run_predus2(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    predus2 = Predus2(pdb_id, chain_id)
+    predus2 = Predus2(pdb_id, chain_id, pdb_file)
     predictions = predus2.run()
     log.info(predictions)
     return predictions
 
 
-def run_predictprotein(pdb_id, chain_id):
+def run_predictprotein(pdb_id, chain_id, pdb_file):
     """
     Run the PREDICTPROTEIN predictor.
 
@@ -195,13 +195,13 @@ def run_predictprotein(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    predictprotein_api = Predictprotein(pdb_id, chain_id)
+    predictprotein_api = Predictprotein(pdb_id, chain_id, pdb_file)
     predictions = predictprotein_api.run()
     log.info(predictions)
     return predictions
 
 
-def run_psiver(pdb_id, chain_id):
+def run_psiver(pdb_id, chain_id, pdb_file):
     """
     Run the PSIVER predictor.
 
@@ -218,7 +218,7 @@ def run_psiver(pdb_id, chain_id):
         Dictionary containing the predictions
 
     """
-    psiver = Psiver(pdb_id, chain_id)
+    psiver = Psiver(pdb_id, chain_id, pdb_file)
     predictions = psiver.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -178,14 +178,14 @@ def run_predus2(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_predictprotein(pdb_id, chain_id, pdb_file):
+def run_predictprotein(pdb_file, chain_id):
     """
     Run the PREDICTPROTEIN predictor.
 
     Parameters
     ----------
-    pdb_id : str
-        Protein data bank identification code.
+    pdb_file : str
+        Path to PDB file.
     chain_id : str
         Chain identifier.
 
@@ -195,7 +195,7 @@ def run_predictprotein(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    predictprotein_api = Predictprotein(pdb_id, chain_id, pdb_file)
+    predictprotein_api = Predictprotein(pdb_file, chain_id)
     predictions = predictprotein_api.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -63,7 +63,7 @@ def run_ispred4(pdb_id, chain_id, pdb_file):
     return predictions
 
 
-def run_scriber(pdb_id, chain_id, pdb_file):
+def run_scriber(pdb_file, chain_id):
     """
     Run the SCRIBER predictor.
 
@@ -80,7 +80,7 @@ def run_scriber(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    scriber = Scriber(pdb_id, chain_id, pdb_file)
+    scriber = Scriber(pdb_file, chain_id)
     predictions = scriber.run()
     log.info(predictions)
     return predictions
@@ -303,9 +303,9 @@ def run_prediction(prediction_method, **kwargs):
 
     """
     if prediction_method in PDB_PREDICTORS:
-        if not kwargs["pdb_id"]:
+        if not kwargs["pdb_file"]:
             raise IncompleteInputError(
-                predictor_name=prediction_method, missing="pdb_id"
+                predictor_name=prediction_method, missing="pdb_file"
             )
 
         if not kwargs["chain_id"]:
@@ -315,7 +315,6 @@ def run_prediction(prediction_method, **kwargs):
 
         predictor_func = partial(
             PDB_PREDICTORS[prediction_method],
-            pdb_id=kwargs["pdb_id"],
             chain_id=kwargs["chain_id"],
             pdb_file=kwargs["pdb_file"],
         )

--- a/src/cport/modules/loader.py
+++ b/src/cport/modules/loader.py
@@ -86,13 +86,13 @@ def run_scriber(pdb_file, chain_id):
     return predictions
 
 
-def run_sppider(pdb_id, chain_id, pdb_file):
+def run_sppider(pdb_file, chain_id):
     """
     Run the WHISCY predictor.
 
     Parameters
     ----------
-    pdb_id : str
+    pdb_file : str
         Protein data bank identification code.
     chain_id : str
         Chain identifier.
@@ -103,7 +103,7 @@ def run_sppider(pdb_id, chain_id, pdb_file):
         Dictionary containing the predictions
 
     """
-    sppider = Sppider(pdb_id, chain_id, pdb_file)
+    sppider = Sppider(pdb_file, chain_id)
     predictions = sppider.run()
     log.info(predictions)
     return predictions

--- a/src/cport/modules/predictprotein_api.py
+++ b/src/cport/modules/predictprotein_api.py
@@ -9,7 +9,7 @@ from io import StringIO
 import pandas as pd
 import requests
 
-from cport.modules.utils import get_fasta_from_pdbid
+from cport.modules.utils import get_fasta_from_pdbfile
 from cport.url import PREDICTPROTEIN_API
 
 log = logging.getLogger("cportlog")
@@ -23,19 +23,19 @@ ELEMENT_LOAD_WAIT = 5  # seconds
 class Predictprotein:
     """PREDICTPROTEIN class."""
 
-    def __init__(self, pdb_id, chain_id):
+    def __init__(self, pdb_file, chain_id):
         """
         Initialize the class.
 
         Parameters
         ----------
-        pdb_id : str
-            Protein data bank identification code.
+        pdb_file : str
+            Path to PDB file.
         chain_id : str
             Chain identifier.
 
         """
-        self.pdb_id = pdb_id
+        self.pdb_file = pdb_file
         self.chain_id = chain_id
         self.wait = WAIT_INTERVAL
         self.tries = NUM_RETRIES
@@ -51,11 +51,9 @@ class Predictprotein:
             prediction results.
 
         """
-        sequence = get_fasta_from_pdbid(self.pdb_id, self.chain_id)
-        # FASTA header must be removed from sequence
-        sequence_headless = "".join(sequence.splitlines(keepends=True)[1:])
+        sequence = get_fasta_from_pdbfile(self.pdb_file, self.chain_id)
 
-        data = {"action": "get", "sequence": sequence_headless, "file": "query.prona"}
+        data = {"action": "get", "sequence": sequence, "file": "query.prona"}
 
         results = requests.post(PREDICTPROTEIN_API, data=json.dumps(data))
 

--- a/src/cport/modules/predus2.py
+++ b/src/cport/modules/predus2.py
@@ -23,19 +23,19 @@ NUM_RETRIES = 6
 class Predus2:
     """Predus2 class."""
 
-    def __init__(self, pdb_id, chain_id):
+    def __init__(self, pdb_file, chain_id):
         """
         Initialize the class.
 
         Parameters
         ----------
-        pdb_id : str
+        pdb_file : str
             Protein data bank identification code.
         chain_id : str
             Chain identifier.
 
         """
-        self.pdb_id = pdb_id
+        self.pdb_file = pdb_file
         self.chain_id = chain_id
         self.prediction_dict = {}
         self.wait = WAIT_INTERVAL
@@ -55,8 +55,7 @@ class Predus2:
         browser.open(PREDUS2_URL, verify=False)
 
         input_form = browser.select_form(nr=0)
-        input_form.set(name="pdbid", value=self.pdb_id)
-        input_form.set(name="chain", value=self.chain_id)
+        input_form.set(name="userfile", value=self.pdb_file)
         browser.submit_selected()
 
         # finds the submission url from the many links present on the page

--- a/src/cport/modules/predus2.py
+++ b/src/cport/modules/predus2.py
@@ -30,7 +30,7 @@ class Predus2:
         Parameters
         ----------
         pdb_file : str
-            Protein data bank identification code.
+            Path to PDB file.
         chain_id : str
             Chain identifier.
 

--- a/src/cport/modules/predus2.py
+++ b/src/cport/modules/predus2.py
@@ -112,10 +112,11 @@ class Predus2:
                 log.error(f"PredUs2 server is not responding, url was {url}")
                 sys.exit()
 
+        pdb_name = str(self.pdb_file)[-8:-4]
         capital_chain_id = self.chain_id.capitalize()
         final_url = (
             "https://honiglab.c2b2.columbia.edu/hfpd/tmp/"
-            f"{self.pdb_id}_{capital_chain_id}.pd2.txt"
+            f"{pdb_name}_{capital_chain_id}.pd2.txt"
         )
 
         browser.close()

--- a/src/cport/modules/predus2.py
+++ b/src/cport/modules/predus2.py
@@ -112,6 +112,7 @@ class Predus2:
                 log.error(f"PredUs2 server is not responding, url was {url}")
                 sys.exit()
 
+        # once the server is running again, check if this is the correct url format!
         pdb_name = str(self.pdb_file)[-8:-4]
         capital_chain_id = self.chain_id.capitalize()
         final_url = (

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -22,7 +22,7 @@ NUM_RETRIES = 12
 class Scriber:
     """SCRIBER class."""
 
-    def __init__(self, pdb_id, chain_id, pdb_file):
+    def __init__(self, pdb_file, chain_id):
         """
         Initialize the class.
 
@@ -34,7 +34,6 @@ class Scriber:
             Chain identifier.
 
         """
-        self.pdb_id = pdb_id
         self.chain_id = chain_id
         self.pdb_file = pdb_file
         self.prediction_dict = {}
@@ -56,12 +55,14 @@ class Scriber:
             pdb_file=self.pdb_file, chain_id=self.chain_id
         )
 
+        submission_string = ">Chain " + self.chain_id + "\n" + fasta_string
+
         browser = ms.StatefulBrowser()
 
         browser.open(SCRIBER_URL)
 
         from_fasta = browser.select_form(nr=0)
-        from_fasta.set(name="seq", value=fasta_string)
+        from_fasta.set(name="seq", value=submission_string)
         from_fasta.set(name="email1", value="")
         browser.submit_selected(btnName="Button1")
         links = browser.links()
@@ -73,7 +74,7 @@ class Scriber:
             log.error("SCRIBER submission failed")
             sys.exit()
 
-        return fasta_string
+        return submitted_url
 
     def retrieve_prediction_link(self, url=None, page_text=None):
         """

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -9,7 +9,7 @@ from urllib import request
 import mechanicalsoup as ms
 import pandas as pd
 
-from cport.modules.utils import get_fasta_from_pdbid
+from cport.modules.utils import get_fasta_from_pdbfile
 from cport.url import SCRIBER_URL
 
 log = logging.getLogger("cportlog")
@@ -22,7 +22,7 @@ NUM_RETRIES = 12
 class Scriber:
     """SCRIBER class."""
 
-    def __init__(self, pdb_id, chain_id):
+    def __init__(self, pdb_id, chain_id, pdb_file):
         """
         Initialize the class.
 
@@ -36,6 +36,7 @@ class Scriber:
         """
         self.pdb_id = pdb_id
         self.chain_id = chain_id
+        self.pdb_file = pdb_file
         self.prediction_dict = {}
         self.wait = WAIT_INTERVAL
         self.tries = NUM_RETRIES
@@ -50,7 +51,10 @@ class Scriber:
             The url of the submitted job.
 
         """
-        fasta_string = get_fasta_from_pdbid(self.pdb_id, self.chain_id)
+        # fasta_string = get_fasta_from_pdbid(self.pdb_id, self.chain_id)
+        fasta_string = get_fasta_from_pdbfile(
+            pdb_file=self.pdb_file, chain_id=self.chain_id
+        )
 
         browser = ms.StatefulBrowser()
 
@@ -69,7 +73,7 @@ class Scriber:
             log.error("SCRIBER submission failed")
             sys.exit()
 
-        return submitted_url
+        return fasta_string
 
     def retrieve_prediction_link(self, url=None, page_text=None):
         """

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -28,8 +28,8 @@ class Scriber:
 
         Parameters
         ----------
-        pdb_id : str
-            Protein data bank identification code.
+        pdb_file : str
+            Path to PDB file.
         chain_id : str
             Chain identifier.
 
@@ -50,7 +50,6 @@ class Scriber:
             The url of the submitted job.
 
         """
-        # fasta_string = get_fasta_from_pdbid(self.pdb_id, self.chain_id)
         fasta_string = get_fasta_from_pdbfile(
             pdb_file=self.pdb_file, chain_id=self.chain_id
         )

--- a/src/cport/modules/sppider.py
+++ b/src/cport/modules/sppider.py
@@ -19,18 +19,18 @@ NUM_RETRIES = 12
 class Sppider:
     """SPPIDER class."""
 
-    def __init__(self, pdb_id, chain_id):
+    def __init__(self, pdb_file, chain_id):
         """Initialize the SPPIDER class.
 
         Parameters
         ----------
-        pdb_id : str
+        pdb_file : str
             Protein data bank identification code.
         chain_id : str
             Chain identifier.
 
         """
-        self.pdb_id = pdb_id
+        self.pdb_file = pdb_file
         self.chain_id = chain_id
         self.wait = WAIT_INTERVAL
         self.tries = NUM_RETRIES
@@ -49,8 +49,7 @@ class Sppider:
         browser.open(SPPIDER_URL)
 
         sppider_form = browser.select_form()
-        sppider_form.set(name="PDBCode", value=self.pdb_id)
-        sppider_form.set(name="PDBChain", value=self.chain_id)
+        sppider_form.set(name="PDBFileName", value=self.pdb_file)
 
         browser.submit_selected()
 

--- a/src/cport/modules/sppider.py
+++ b/src/cport/modules/sppider.py
@@ -25,7 +25,7 @@ class Sppider:
         Parameters
         ----------
         pdb_file : str
-            Protein data bank identification code.
+            Path to PDB file.
         chain_id : str
             Chain identifier.
 

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -130,7 +130,7 @@ def get_fasta_from_pdbfile(pdb_file, chain_id):
     return sequence
 
 
-def format_output(result_dic, output_fname, chain_id, pdb_file):
+def format_output(result_dic, output_fname, pdb_file, chain_id):
     """
     Format the results into a human-readable format.
 

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -9,6 +9,7 @@ from urllib import request
 
 import pandas as pd
 import requests
+from Bio import SeqIO
 
 from cport.url import PDB_FASTA_URL, PDB_URL
 
@@ -103,6 +104,30 @@ def get_pdb_from_pdbid(pdb_id):
     pdb_fname = temp_file.name
 
     return pdb_fname
+
+
+def get_fasta_from_pdbfile(pdb_file, chain_id):
+    """
+    Extract FASTA sequence from supplied PDB file.
+
+    Parameters
+    ----------
+    pdb_file : str
+        Path to the supplied PDB file.
+    chain_id : str
+        Specific chain to return the FASTA string from.
+
+    Returns
+    -------
+    sequence : str
+        String of the FASTA sequence.
+
+    """
+    with open(pdb_file) as handle:
+        for record in SeqIO.PdbIO.PdbSeqresIterator(handle):
+            if record.id[-1] == chain_id:
+                sequence = str(record.seq)
+    return sequence
 
 
 def format_output(result_dic, output_fname, chain_id, pdb_file):

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -125,6 +125,7 @@ def get_fasta_from_pdbfile(pdb_file, chain_id):
     """
     with open(pdb_file) as handle:
         for record in SeqIO.PdbIO.PdbSeqresIterator(handle):
+            # checks all the chains to find match with chain_id
             if record.id[-1] == chain_id:
                 sequence = str(record.seq)
     return sequence

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -105,7 +105,7 @@ def get_pdb_from_pdbid(pdb_id):
     return pdb_fname
 
 
-def format_output(result_dic, output_fname, pdb_id, chain_id):
+def format_output(result_dic, output_fname, chain_id, pdb_file):
     """
     Format the results into a human-readable format.
 
@@ -117,7 +117,7 @@ def format_output(result_dic, output_fname, pdb_id, chain_id):
         The output file name.
 
     """
-    standardized_dic = standardize_residues(result_dic, pdb_id, chain_id)
+    standardized_dic = standardize_residues(result_dic, chain_id, pdb_file)
     reslist = get_residue_range(standardized_dic)
     data = []
     for pred in result_dic:
@@ -205,7 +205,7 @@ def get_residue_range(result_dic):
     return absolute_range
 
 
-def standardize_residues(result_dic, pdb_id, chain_id):
+def standardize_residues(result_dic, chain_id, pdb_file):
     """
     Standardize the residues from different predictors
     into a uniform numbering system starting at 1.
@@ -221,9 +221,8 @@ def standardize_residues(result_dic, pdb_id, chain_id):
         The standardized results dict
 
     """
-    pdb_file = get_pdb_from_pdbid(pdb_id)
     # https://regex101.com/r/UdPJ7I/1
-    bias_regex = r"DBREF\s\s" + pdb_id.upper() + r"\s" + chain_id + r"\s\s\s(.*?)\s\s\s"
+    bias_regex = r"DBREF\s\s.*?\s" + chain_id + r"\s\s\s(.*?)\s\s\s"
 
     f = open(pdb_file, "r")
     pdb_text = "\n".join(f.read().splitlines())

--- a/src/cport/modules/whiscy.py
+++ b/src/cport/modules/whiscy.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 import time
+from pathlib import Path
 
 import mechanicalsoup as ms
 from Bio import AlignIO
@@ -30,13 +31,13 @@ class Whiscy:
 
         Parameters
         ----------
-        pdb_file : str
+        pdb_file : str or PosixPath
             Path to PDB file.
         chain_id : str
             Chain identifier.
 
         """
-        self.pdb_file = pdb_file
+        self.pdb_file = Path(pdb_file)
         self.chain_id = chain_id
         self.wait = WAIT_INTERVAL
         self.tries = NUM_RETRIES
@@ -51,12 +52,11 @@ class Whiscy:
             The url to the processing page.
 
         """
-        # take the exact name of the pdb input without the entire path
-        filename = str(self.pdb_file)[-8:]
         # A temporary file needs to be created to avoid WHISCY renaming the input
         # to the entire path name causing the prediction to not run as the name
         # of the input needs to match the hssp name otherwise it will not match
         # A more elegant workaround would be preferable, but eludes me as of yet
+        filename = Path(f"{self.pdb_file.stem}_whiscy.pdb")
         shutil.copyfile(self.pdb_file, filename)
 
         blast_seq = get_fasta_from_pdbfile(self.pdb_file, self.chain_id)

--- a/src/cport/modules/whiscy.py
+++ b/src/cport/modules/whiscy.py
@@ -49,9 +49,10 @@ class Whiscy:
         """
         # take the exact name of the pdb input without the entire path
         filename = str(self.pdb_file)[-8:]
-        # a temporary file needs to be created to avoid WHISCY renaming the input
+        # A temporary file needs to be created to avoid WHISCY renaming the input
         # to the entire path name causing the prediction to not run as the name
         # of the input needs to match the hssp name otherwise it will not match
+        # A more elegant workaround would be preferable, but eludes me as of yet
         shutil.copyfile(self.pdb_file, filename)
 
         browser = ms.StatefulBrowser()
@@ -72,6 +73,7 @@ class Whiscy:
         new_url = re.findall(r"(https:.*)\"", page_text_list)[0]
 
         browser.close()
+        # remove file in main directory for cleanliness
         os.unlink(filename)
 
         return new_url

--- a/tests/test_cons_ppisp.py
+++ b/tests/test_cons_ppisp.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def cons_ppisp():
-    yield ConsPPISP("1PPE", "E")
+    yield ConsPPISP("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the cons-PPISP server is up")

--- a/tests/test_csm_potential.py
+++ b/tests/test_csm_potential.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def csm_potential():
-    yield CsmPotential("1ppe", "E", "/Users/aldovandennieuwendijk/Documents/GitHub/cport/tests/test_data/1PPE.pdb")
+    yield CsmPotential("1ppe", "E", "tests/test_data/1PPE.pdb")
 
 
 @pytest.mark.skip("Cannot guarantee that the CSM-Potential server is up")

--- a/tests/test_csm_potential.py
+++ b/tests/test_csm_potential.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def csm_potential():
-    yield CsmPotential("1ppe", "E", "tests/test_data/1PPE.pdb")
+    yield CsmPotential("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the CSM-Potential server is up")

--- a/tests/test_csm_potential.py
+++ b/tests/test_csm_potential.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def csm_potential():
-    yield CsmPotential("1ppe", "E")
+    yield CsmPotential("1ppe", "E", "/Users/aldovandennieuwendijk/Documents/GitHub/cport/tests/test_data/1PPE.pdb")
 
 
 @pytest.mark.skip("Cannot guarantee that the CSM-Potential server is up")

--- a/tests/test_ispred4.py
+++ b/tests/test_ispred4.py
@@ -14,7 +14,7 @@ def precalc_result():
 
 @pytest.fixture
 def ispred4():
-    yield Ispred4("1PPE", "E")
+    yield Ispred4("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the ISPRED4 server is up")

--- a/tests/test_meta_ppisp.py
+++ b/tests/test_meta_ppisp.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def meta_ppisp():
-    yield MetaPPISP("1PPE", "E")
+    yield MetaPPISP("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the meta-PPISP server is up")

--- a/tests/test_predictprotein.py
+++ b/tests/test_predictprotein.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def predictprotein():
-    yield Predictprotein("1ppe", "E")
+    yield Predictprotein("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the Predict Protein server is up")

--- a/tests/test_predus2.py
+++ b/tests/test_predus2.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def predus2():
-    yield Predus2("1ppe", "E")
+    yield Predus2("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the PredUs2 server is up")

--- a/tests/test_predus2.py
+++ b/tests/test_predus2.py
@@ -24,7 +24,7 @@ def test_submit():
 def test_retrieve_prediction_link(predus2):
     page_text = "PredUs2.0 result file:"
     observed_download_url = predus2.retrieve_prediction_link(page_text=page_text)
-    expected_download_url = "https://honiglab.c2b2.columbia.edu/hfpd/tmp/1ppe_E.pd2.txt"
+    expected_download_url = "https://honiglab.c2b2.columbia.edu/hfpd/tmp/1PPE_E.pd2.txt"
     assert observed_download_url == expected_download_url
 
 

--- a/tests/test_psiver.py
+++ b/tests/test_psiver.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def psiver():
-    yield Psiver("1PPE", "E")
+    yield Psiver("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the PSIVER server is up")

--- a/tests/test_scriber.py
+++ b/tests/test_scriber.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def scriber():
-    yield Scriber("1PPE", "E")
+    yield Scriber("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the Scriber server is up")

--- a/tests/test_sppider.py
+++ b/tests/test_sppider.py
@@ -13,7 +13,7 @@ def precalc_result():
 
 @pytest.fixture
 def sppider():
-    yield Sppider("1PPE", "E")
+    yield Sppider("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot guarantee that the SPPIDER server is up")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,10 +44,10 @@ def test_get_pdb_from_pdbid():
     assert filecmp.cmp(observed_pdb, expected_pdb)
 
 
-def test_format_output(test_result_dic, pdb_id = "1PPE", chain_id = "E"):
+def test_format_output(test_result_dic, pdb_file = "tests/test_data/1PPE.pdb", chain_id = "E"):
 
     output_f = Path(tempfile.NamedTemporaryFile(delete=False, mode="w+").name)
-    format_output(test_result_dic, output_f, pdb_id, chain_id)
+    format_output(test_result_dic, output_f, pdb_file, chain_id)
 
     expected_output_f = Path(
         Path(__file__).parents[1], "tests/test_data/test_output.csv"

--- a/tests/test_whiscy.py
+++ b/tests/test_whiscy.py
@@ -6,7 +6,7 @@ from cport.modules.whiscy import Whiscy
 
 @pytest.fixture
 def whiscy():
-    yield Whiscy("1PPE", "E")
+    yield Whiscy("tests/test_data/1PPE.pdb", "E")
 
 
 @pytest.mark.skip("Cannot test the submission")


### PR DESCRIPTION
Added `get_fasta_from_pdbfile` in utils.py to extract FASTA sequence from specific chains in the PDB file.
The `get_fasta_from_pdbid` and `get_pdb_from_pdbid` functions in utils.py should be redundant now.

Refactored every predictor to be supplied with a PDB file and use this for the prediction instead of a PDB ID.
For the WHISCY server, using a PDB file is a bit trickier and required a workaround to get the runs to not crash.
Currently, the PredUs2 server is not running any predictions, therefore the full implementation of PDB files could not be tested yet for this server. A guesstimate has been done with the implementation, but should definitely be checked again once the server is online again.