### PR TITLE
Threading for prediction retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please also refer to the original publication:
 
 | Server                                                           | Status | Implemented |
 | ---------------------------------------------------------------- | ------ | ----------- |
-| [WHISCY](https://wenmr.science.uu.nl/whiscy/)                    | 🟢     | ✔️          |
+| [WHISCY](https://wenmr.science.uu.nl/whiscy/)                    | 🔴     |             |
 | [SCRIBER](http://biomine.cs.vcu.edu/servers/SCRIBER/)            | 🟢     | ✔️          |
 | [ISPRED4](https://ispred4.biocomp.unibo.it/ispred/default/index) | 🟢     | ✔️          |
 | [SPPIDER](https://sppider.cchmc.org)                             | 🟢     | ✔️          |

--- a/etc/config.json
+++ b/etc/config.json
@@ -11,7 +11,6 @@
     "predus2",
     "predictprotein",
     "psiver",
-    "csm_potential",
-    "placeholder"
+    "csm_potential"
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ mypy-extensions==0.4.3
 numpy
 pandas
 pathspec==0.9.0
+pdb-tools==2.4.11
 platformdirs==2.5.2
 python-dateutil==2.8.2
 pytz==2022.1

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -49,7 +49,7 @@ argument_parser.add_argument(
     "--pred",
     nargs="+",
     default=["all"],
-    choices=CONFIG["predictors"] + ["all"],
+    choices=CONFIG["predictors"] + ["all"] + ["fast"],
     help="",
 )
 
@@ -141,6 +141,16 @@ def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
 
     if "all" in pred:
         pred = CONFIG["predictors"]
+
+    if "fast" in pred:
+        pred = [
+            "scriber",
+            "ispred4",
+            "sppider",
+            "cons_ppisp",
+            "predictprotein",
+            "csm_potential",
+        ]
 
     threads = {}
 

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from cport.modules.loader import run_prediction
+from cport.modules.threadreturn import ThreadReturnVal
 from cport.modules.utils import format_output
 from cport.version import VERSION
 
@@ -141,14 +142,26 @@ def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
     if "all" in pred:
         pred = CONFIG["predictors"]
 
+    threads = {}
+
+    # prepare a dict of predictor initializations.
     for predictor in pred:
+        threads[predictor] = ThreadReturnVal(
+            target=run_prediction, args=predictor, kwargs=data
+        )
+
+    for predictor in threads:
         try:
-            predictions = run_prediction(predictor, **data)
-            result_dic[predictor] = predictions
+            # initiate threads for predictors.
+            threads[predictor].start()
         except Exception as thrown_exception:
             log.error(f"Error running {predictor}")
             log.error(thrown_exception)
             sys.exit()
+
+    for predictor in threads:
+        # retrieve results from predictions with modified join
+        result_dic[predictor] = threads[predictor].join()
 
     # Ouput results #==================================================================#
     format_output(

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -164,9 +164,10 @@ def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
         result_dic[predictor] = threads[predictor].join()
 
     # Ouput results #==================================================================#
+    filename = pdb_file[-8:-4]
     format_output(
         result_dic,
-        output_fname="cport.csv",
+        output_fname="cport_" + filename + ".csv",
         pdb_file=pdb_file,
         chain_id=chain_id,
     )

--- a/src/cport/cli.py
+++ b/src/cport/cli.py
@@ -174,10 +174,10 @@ def main(pdb_file, chain_id, pdb_id, pred, fasta_file):
         result_dic[predictor] = threads[predictor].join()
 
     # Ouput results #==================================================================#
-    filename = pdb_file[-8:-4]
+    filename = Path(pdb_file)
     format_output(
         result_dic,
-        output_fname="cport_" + filename + ".csv",
+        output_fname="cport_" + filename.stem + ".csv",
         pdb_file=pdb_file,
         chain_id=chain_id,
     )

--- a/src/cport/modules/cons_ppisp.py
+++ b/src/cport/modules/cons_ppisp.py
@@ -17,7 +17,7 @@ log = logging.getLogger("cportlog")
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
 # any request should never take more than 15min so theoretical max is 90 retries
-NUM_RETRIES = 18
+NUM_RETRIES = 24
 
 
 class ConsPPISP:

--- a/src/cport/modules/csm_potential.py
+++ b/src/cport/modules/csm_potential.py
@@ -13,7 +13,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 30  # seconds
-NUM_RETRIES = 12
+NUM_RETRIES = 24
 ELEMENT_LOAD_WAIT = 5  # seconds
 
 

--- a/src/cport/modules/ispred4.py
+++ b/src/cport/modules/ispred4.py
@@ -15,7 +15,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 6
+NUM_RETRIES = 24
 
 
 class Ispred4:

--- a/src/cport/modules/meta_ppisp.py
+++ b/src/cport/modules/meta_ppisp.py
@@ -20,7 +20,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 60  # seconds
-NUM_RETRIES = 30
+NUM_RETRIES = 300
 
 
 class MetaPPISP:

--- a/src/cport/modules/meta_ppisp.py
+++ b/src/cport/modules/meta_ppisp.py
@@ -19,8 +19,8 @@ from cport.url import META_PPISP_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 6
+WAIT_INTERVAL = 60  # seconds
+NUM_RETRIES = 30
 
 
 class MetaPPISP:

--- a/src/cport/modules/meta_ppisp.py
+++ b/src/cport/modules/meta_ppisp.py
@@ -164,7 +164,7 @@ class MetaPPISP:
         if test_file:
             final_predictions = pd.read_csv(
                 test_file,
-                skiprows=11,
+                skiprows=12,
                 delim_whitespace=True,
                 names=[
                     "AA",
@@ -186,7 +186,7 @@ class MetaPPISP:
             file = self.download_result(url)
             final_predictions = pd.read_csv(
                 io.StringIO(file.decode("utf-8")),
-                skiprows=11,
+                skiprows=12,
                 delim_whitespace=True,
                 names=[
                     "AA",

--- a/src/cport/modules/predictprotein_api.py
+++ b/src/cport/modules/predictprotein_api.py
@@ -16,7 +16,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 30  # seconds
-NUM_RETRIES = 12
+NUM_RETRIES = 24
 ELEMENT_LOAD_WAIT = 5  # seconds
 
 

--- a/src/cport/modules/predictprotein_api.py
+++ b/src/cport/modules/predictprotein_api.py
@@ -52,6 +52,9 @@ class Predictprotein:
 
         """
         sequence = get_fasta_from_pdbfile(self.pdb_file, self.chain_id)
+        # unreadable aa or HETATM causes an insertion of X, which is not accepted
+        # by removing any X the correct sequence is restored
+        sequence = sequence.replace("X", "")
 
         data = {"action": "get", "sequence": sequence, "file": "query.prona"}
 

--- a/src/cport/modules/predus2.py
+++ b/src/cport/modules/predus2.py
@@ -16,7 +16,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 6
+NUM_RETRIES = 24
 # first run of a protein takes longer, repeat runs use stored data
 
 

--- a/src/cport/modules/psiver.py
+++ b/src/cport/modules/psiver.py
@@ -21,7 +21,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 6
+NUM_RETRIES = 24
 
 
 class Psiver:

--- a/src/cport/modules/psiver.py
+++ b/src/cport/modules/psiver.py
@@ -20,8 +20,8 @@ from cport.url import PSIVER_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 24
+WAIT_INTERVAL = 60  # seconds
+NUM_RETRIES = 300
 
 
 class Psiver:

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -53,6 +53,7 @@ class Scriber:
         fasta_string = get_fasta_from_pdbfile(
             pdb_file=self.pdb_file, chain_id=self.chain_id
         )
+        fasta_string = fasta_string.replace("X", "")
 
         submission_string = ">Chain " + self.chain_id + "\n" + fasta_string
 

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -16,7 +16,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 12
+NUM_RETRIES = 24
 
 
 class Scriber:

--- a/src/cport/modules/sppider.py
+++ b/src/cport/modules/sppider.py
@@ -13,7 +13,7 @@ log = logging.getLogger("cportlog")
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
 # results take up to 5 minutes for 1ppe E, but are usually ready within 2 minutes
-NUM_RETRIES = 12
+NUM_RETRIES = 24
 
 
 class Sppider:
@@ -144,6 +144,7 @@ class Sppider:
         """
         # sppider only provides a list of active residues
         prediction_dict = {"active": [], "passive": []}
+        prediction = {"active": []}
         browser = ms.StatefulBrowser()
 
         if page_text:
@@ -167,7 +168,10 @@ class Sppider:
         active_list = re.sub(r"[A-Z]", "", page_search[0])
 
         # splits on any non-word character, creating a list of all active residues
-        prediction_dict["active"] = re.split(r"\W+", active_list)
+        prediction["active"] = re.split(r"\W+", active_list)
+
+        for item in prediction["active"]:
+            prediction_dict["active"].append(int(item))
 
         return prediction_dict
 

--- a/src/cport/modules/threadreturn.py
+++ b/src/cport/modules/threadreturn.py
@@ -1,0 +1,18 @@
+"""Modified implementation of join from Thread to return a value."""
+from threading import Thread
+
+
+class ThreadReturnVal(Thread):
+    def __init__(
+        self, group=None, target=None, name=None, args=(), kwargs={}, Verbose=None
+    ):
+        Thread.__init__(self, group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(self._args, **self._kwargs)
+
+    def join(self, *args):
+        Thread.join(self, *args)
+        return self._return

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -37,6 +37,7 @@ pdb_predictors = [
 ]
 
 
+# currently unused function
 def get_fasta_from_pdbid(pdb_id, chain_id):
     """
     Retrieve the Fasta string file given a PDBid/Chain.
@@ -81,6 +82,7 @@ def get_fasta_from_pdbid(pdb_id, chain_id):
         return fasta_seq
 
 
+# currently unused function
 def get_pdb_from_pdbid(pdb_id):
     """
     Retrieve the PDB file from a given PDBid.

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -247,13 +247,13 @@ def standardize_residues(result_dic, chain_id, pdb_file):
         The standardized results dict
 
     """
-    # https://regex101.com/r/UdPJ7I/1
-    bias_regex = r"DBREF\s\s.*?\s" + chain_id + r"\s\s\s(.*?)\s\s\s"
+    # https://regex101.com/r/jQFPmY/1
+    bias_regex = r"\S"
 
     f = open(pdb_file, "r")
     pdb_text = "\n".join(f.read().splitlines())
     # pdb files start at a number residue, so remove this bias
-    bias = int(re.findall(bias_regex, pdb_text)[0]) - 1
+    bias = int(re.findall(bias_regex, pdb_text)[10]) - 1
 
     # if there was no bias present, then no need to run through this block
     if bias != 0:

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -124,10 +124,11 @@ def get_fasta_from_pdbfile(pdb_file, chain_id):
 
     """
     with open(pdb_file) as handle:
-        for record in SeqIO.PdbIO.PdbSeqresIterator(handle):
-            # checks all the chains to find match with chain_id
+        for record in SeqIO.PdbIO.PdbAtomIterator(handle):
+            # checks for matching chain id
             if record.id[-1] == chain_id:
                 sequence = str(record.seq)
+
     return sequence
 
 

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -247,13 +247,13 @@ def standardize_residues(result_dic, chain_id, pdb_file):
         The standardized results dict
 
     """
-    # https://regex101.com/r/jQFPmY/1
-    bias_regex = r"\S"
+    # https://regex101.com/r/1myWjv/1
+    bias_regex = r"ATOM\s{6}1\s*\S*\s*\S{3}\s\S\s*(\S*)"
 
     f = open(pdb_file, "r")
     pdb_text = "\n".join(f.read().splitlines())
     # pdb files start at a number residue, so remove this bias
-    bias = int(re.findall(bias_regex, pdb_text)[10]) - 1
+    bias = int(re.findall(bias_regex, pdb_text)[0]) - 1
 
     # if there was no bias present, then no need to run through this block
     if bias != 0:

--- a/src/cport/modules/whiscy.py
+++ b/src/cport/modules/whiscy.py
@@ -19,7 +19,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 6
+NUM_RETRIES = 24
 
 
 class Whiscy:


### PR DESCRIPTION
Implemented concurrent prediction retrieval via the Threading module. This module does not return a value from the threads, for this reason a modified version of the `.join()` function was created that did return a value.
The returned results were also observed to remain unaffected by the implementation of threading, so no artefacts should be present in the results.
Additionally, the maximum wait times for the fast predictors has been increased and somewhat standardised, as well as for the slow predictors. The fast predictors should take no longer than a few minutes to return their results. The slow predictors have been given a window of around 5 hours, which is generally enough time unless they are already quite busy with other predictions.