### PR TITLE
Standardisation redo

### DIFF
--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -9,7 +9,7 @@ from urllib import request
 
 import pandas as pd
 import requests
-from Bio import SeqIO
+from Bio import SeqIO, PDB
 
 from cport.url import PDB_FASTA_URL, PDB_URL
 
@@ -273,3 +273,17 @@ def standardize_residues(result_dic, chain_id, pdb_file):
                     result_dic[pred]["passive"][index[0]] += bias
 
     return result_dic
+
+
+def get_residue_list(pdb_file="tests/test_data/1PPE.pdb", chain_id="E"):
+    parser = PDB.PDBParser()
+    structure = parser.get_structure("pdb", pdb_file)
+    model = structure[0]
+    chain = model[chain_id]
+    residue_list = []
+
+    for residue in chain:
+        if residue.get_full_id()[3][0] == " ":
+            residue_list.append(residue.get_id()[1])
+
+    return residue_list

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -238,7 +238,8 @@ def get_residue_range(result_dic):
 def standardize_residues(result_dic, chain_id, pdb_file):
     """
     Standardize the residues from different predictors
-    into a uniform numbering system starting at 1.
+    into a uniform numbering system starting at 1 and
+    prevents any shifts due to gaps in the PDB file.
 
     Parameters
     ----------
@@ -275,6 +276,7 @@ def standardize_residues(result_dic, chain_id, pdb_file):
                 for index in enumerate(result_dic[pred]["passive"]):
                     result_dic[pred]["passive"][index[0]] += bias
 
+    # find any missing items from the residue list in the PDB file
     missing_list = []
     for ele in range(reslist[0], reslist[-1] + 1):
         if ele not in reslist:
@@ -284,6 +286,7 @@ def standardize_residues(result_dic, chain_id, pdb_file):
         # dummy addition to keep the iteration working
         missing_list.append(10000000)
         for pred in result_dic:
+            # these use sequences and do not see missing items
             if pred == "predictprotein" or pred == "scriber":
                 item = 0
                 bias = 0
@@ -314,7 +317,17 @@ def standardize_residues(result_dic, chain_id, pdb_file):
     return result_dic
 
 
-def get_residue_list(pdb_file="tests/test_data/1PPE.pdb", chain_id="E"):
+def get_residue_list(pdb_file, chain_id):
+    """
+    Extract list of residues present in PDB file.
+
+    Parameters
+    ----------
+    pdb_file : str
+        Path to the file that has to be parsed.
+    chain_id : str
+        Letter to indicate which chain to use from the file.
+    """
     parser = PDB.PDBParser()
     structure = parser.get_structure("pdb", pdb_file)
     model = structure[0]

--- a/src/cport/modules/utils.py
+++ b/src/cport/modules/utils.py
@@ -261,15 +261,15 @@ def standardize_residues(result_dic, chain_id, pdb_file):
     # if there was no bias present, then no need to run through this block
     if bias != 0:
         for pred in result_dic:
-            if pred not in scored_predictors and pred in pdb_predictors:
+            if pred not in scored_predictors and pred not in pdb_predictors:
                 for index in enumerate(result_dic[pred]["active"]):
-                    result_dic[pred]["active"][index[0]] -= bias
+                    result_dic[pred]["active"][index[0]] += bias
                 for index in enumerate(result_dic[pred]["passive"]):
-                    result_dic[pred]["passive"][index[0]] -= bias
-            elif pred in pdb_predictors:
+                    result_dic[pred]["passive"][index[0]] += bias
+            elif pred in scored_predictors and pred not in pdb_predictors:
                 for index in enumerate(result_dic[pred]["active"]):
-                    result_dic[pred]["active"][index[0]][0] -= bias
+                    result_dic[pred]["active"][index[0]][0] += bias
                 for index in enumerate(result_dic[pred]["passive"]):
-                    result_dic[pred]["passive"][index[0]] -= bias
+                    result_dic[pred]["passive"][index[0]] += bias
 
     return result_dic

--- a/tests/test_data/test_output.csv
+++ b/tests/test_data/test_output.csv
@@ -1,3 +1,3 @@
-predictor,1,2,3,4,5,6
+predictor,16,17,18,19,20,21
 something,P,A,-,-,P,A
 somethingelse,-,A,A,-,P,-


### PR DESCRIPTION
Originally the standardisation set everything to begin at 1, this proved difficult for statistical analysis, so was redone to standardise everything to the starting point in the PDB file of the protein.
This also revealed the fact that the sequence predictors (predict protein and scriber) did not account for any potential gaps in the PDB file, unlike the structure predictors. This caused their predictions to shift everytime there was a gap.
To prevent this, a special section was added to the `standardize_residues` function and a new `get_residue_list` function was added.
These allow CPORT to check if there were any gaps in the PDB residues, and if needed adjust the active residue numbers from the sequence predictors accordingly depending on where in the sequence they are.