### PR TITLE
Cons ppisp csv fix

### DIFF
--- a/src/cport/modules/cons_ppisp.py
+++ b/src/cport/modules/cons_ppisp.py
@@ -177,7 +177,7 @@ class ConsPPISP:
                 delim_whitespace=True,
                 names=["AA", "Ch", "AA_nr", "Score", "Prediction"],
                 header=0,
-                skipfooter=16,
+                error_bad_lines=False
             )
 
         for row in final_predictions.itertuples():

--- a/src/cport/modules/cons_ppisp.py
+++ b/src/cport/modules/cons_ppisp.py
@@ -177,7 +177,7 @@ class ConsPPISP:
                 delim_whitespace=True,
                 names=["AA", "Ch", "AA_nr", "Score", "Prediction"],
                 header=0,
-                error_bad_lines=False
+                error_bad_lines=False,
             )
 
         for row in final_predictions.itertuples():


### PR DESCRIPTION
The results from cons-PPISP contain a footer in the csv which can have a variable length based on the number of predicted interaction sites. The reading of the csv was therefore changed to disregard any lines that do not fit the described structure. This way, instead of throwing an error, it will read in the results without any lines being accidentally added or lost.