### PR TITLE
Sppider result fix

### DIFF
--- a/src/cport/modules/cons_ppisp.py
+++ b/src/cport/modules/cons_ppisp.py
@@ -15,9 +15,9 @@ from cport.url import CONS_PPISP_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
+WAIT_INTERVAL = 30  # seconds
 # any request should never take more than 15min so theoretical max is 90 retries
-NUM_RETRIES = 24
+NUM_RETRIES = 36
 
 
 class ConsPPISP:

--- a/src/cport/modules/csm_potential.py
+++ b/src/cport/modules/csm_potential.py
@@ -13,7 +13,7 @@ log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
 WAIT_INTERVAL = 30  # seconds
-NUM_RETRIES = 24
+NUM_RETRIES = 36
 ELEMENT_LOAD_WAIT = 5  # seconds
 
 

--- a/src/cport/modules/ispred4.py
+++ b/src/cport/modules/ispred4.py
@@ -14,8 +14,8 @@ from cport.url import ISPRED4_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 24
+WAIT_INTERVAL = 30  # seconds
+NUM_RETRIES = 36
 
 
 class Ispred4:

--- a/src/cport/modules/predictprotein_api.py
+++ b/src/cport/modules/predictprotein_api.py
@@ -15,8 +15,8 @@ from cport.url import PREDICTPROTEIN_API
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 30  # seconds
-NUM_RETRIES = 24
+WAIT_INTERVAL = 45  # seconds
+NUM_RETRIES = 36
 ELEMENT_LOAD_WAIT = 5  # seconds
 
 

--- a/src/cport/modules/scriber.py
+++ b/src/cport/modules/scriber.py
@@ -15,8 +15,8 @@ from cport.url import SCRIBER_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
-NUM_RETRIES = 24
+WAIT_INTERVAL = 30  # seconds
+NUM_RETRIES = 36
 
 
 class Scriber:

--- a/src/cport/modules/sppider.py
+++ b/src/cport/modules/sppider.py
@@ -11,9 +11,9 @@ from cport.url import SPPIDER_URL
 log = logging.getLogger("cportlog")
 
 # Total wait (seconds) = WAIT_INTERVAL * NUM_RETRIES
-WAIT_INTERVAL = 10  # seconds
+WAIT_INTERVAL = 30  # seconds
 # results take up to 5 minutes for 1ppe E, but are usually ready within 2 minutes
-NUM_RETRIES = 24
+NUM_RETRIES = 36
 
 
 class Sppider:
@@ -164,14 +164,16 @@ class Sppider:
 
         browser.close()
 
-        # removes aa identifier to only retain the position of the residues
-        active_list = re.sub(r"[A-Z]", "", page_search[0])
+        # checks if any residues are actually predicted
+        if page_search != ["None"]:
+            # removes aa identifier to only retain the position of the residues
+            active_list = re.sub(r"[A-Z]", "", page_search[0])
 
-        # splits on any non-word character, creating a list of all active residues
-        prediction["active"] = re.split(r"\W+", active_list)
+            # splits on any non-word character, creating a list of all active residues
+            prediction["active"] = re.split(r"\W+", active_list)
 
-        for item in prediction["active"]:
-            prediction_dict["active"].append(int(item))
+            for item in prediction["active"]:
+                prediction_dict["active"].append(int(item))
 
         return prediction_dict
 


### PR DESCRIPTION
Increased time for predictors to return results as some timed out when predicting larger structures. Also fixed an issue with sppider predictor where if there were no active sites predicted, it would cause an error in creating the result dictionary.
Now, before trying to create the dictionary,  it will first check if there are any active sites predicted and only continue if there is at least one.